### PR TITLE
small patches to make production build work with current webpack version

### DIFF
--- a/webpack/base.js
+++ b/webpack/base.js
@@ -17,7 +17,7 @@ const prodPlugins = [],
   isProd = process.env.NODE_ENV === "production";
 
 if (isProd) {
-  prodPlugins.push(new optimize.AggressiveMergingPlugin(), new optimize.OccurrenceOrderPlugin());
+  prodPlugins.push(new optimize.AggressiveMergingPlugin());
 }
 
 const Root = join(__dirname, "..");
@@ -34,7 +34,7 @@ const Option = join(Source, "option");
 const config = {
   mode: process.env.NODE_ENV,
   target: "web",
-  devtool: isProd ? "none" : "cheap-source-map",
+  devtool: isProd ? false : "cheap-source-map",
   entry: {
     background: join(Background, "index.ts"),
     popup: join(Popup, "index.tsx"),


### PR DESCRIPTION
- new optimize.OccurrenceOrderPlugin() is there by default; see https://github.com/js-dxtools/webpack-validator/issues/155
- "devtool: false" works as expected (does not produce map files); build did not work using "none"

tested with node v18.13.0
