### PR TITLE
fix recursive fs.watch for linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "fs-extra": "^11.1.0",
         "get-installed-browsers": "^0.1.7",
+        "node-watch": "^0.7.3",
         "postcss": "^8.4.21",
         "rimraf": "^4.1.1",
         "tailwindcss": "^3.2.6",
@@ -6371,6 +6372,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
       "dev": true
+    },
+    "node_modules/node-watch": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
+      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -13803,6 +13813,12 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+      "dev": true
+    },
+    "node-watch": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
+      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
       "dev": true
     },
     "normalize-path": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "fs-extra": "^11.1.0",
     "get-installed-browsers": "^0.1.7",
+    "node-watch": "^0.7.3",
     "postcss": "^8.4.21",
     "rimraf": "^4.1.1",
     "tailwindcss": "^3.2.6",


### PR DESCRIPTION
Recursive fs.watch [does not work on Linux](https://nodejs.org/docs/latest-v18.x/api/fs.html#caveats).
1. Use node-watch instead of fs.watch.
2. Bug-fix: Delete public file from dist if it got deleted in source.