### PR TITLE
Do not hash html filename

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -119,6 +119,7 @@ async function buildHtmlPage(name: string, entry: string, outdir: string, dev = 
       ".svg": "dataurl",
       ".json": "json",
     },
+    assetNames: '[name]',
     plugins: [
       html({
         entryNames: "[name]-[hash]",


### PR DESCRIPTION
Hi,

This merge request disable hash in filename for html asset. This will cause generated file that looked like `./dist/v3/popup/index-BZ5QGGTW.html` to become `./dist/v3/popup/index.html`.

The feature of esbuild make html files harder to reference in the webextension `manifest.json` especially during watch. Once disabled this resolves #13 and resolves #14). Besides it make it easier to predict url between html pages within the webextension.

Regards,
Pascal Noisette