### PR TITLE
fix css import

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -136,6 +136,22 @@ async function buildHtmlPage(name: string, entry: string, outdir: string, dev = 
     ],
   });
 
+
+  const cssFiles = fs.readdirSync(resolve(outdir, name)).filter((file: string) => file.endsWith('.css'));
+
+  if(cssFiles.length > 0) {
+    const indexHtmlPath = resolve(outdir, name, "index.html");
+    let indexHtmlContent = fs.readFileSync(indexHtmlPath, 'utf8');
+    const allLinkTags = cssFiles.map((file: string) => {
+      return `<link rel="stylesheet" href="${file}">`;
+    });
+    indexHtmlContent = indexHtmlContent.replace('</head>', `${allLinkTags}\n</head>`);
+
+    fs.writeFileSync(indexHtmlPath, indexHtmlContent);
+  }
+
+
+
   console.timeEnd(prompt);
   
   return out;


### PR DESCRIPTION
The CSS file is not being added to the HTML file, therefore, any styling is not being applied to the build.
I don't know how Esbuild is supposed to create the link tags, I've no idea why it's not happening so I'm adding this workaround that may be useful while the project doesn't have a better fix.