### PR TITLE
Wait for build to complete before launching browser

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -589,7 +589,7 @@ function DevBrowserExt(browsers: string[]) {
     versions = MatchExtVersions(matchedBrowsers);
   }
 
-  DevVersionedExt(versions);
+  const build = DevVersionedExt(versions);
 
   const profileRoot = CreateProfileRoot();
   const commands: string[] = [];
@@ -607,9 +607,8 @@ function DevBrowserExt(browsers: string[]) {
     commands.push("sleep 100000"); // TODO: A more elegant way of doing nothing?
   }
 
-  const { result } = concurrently(commands);
-
-  result
+  build
+    .then(() => concurrently(commands).result)
     .then(() => {
       console.log("All processes exited");
       process.exit(0);


### PR DESCRIPTION
When `web-ext` is launched before the build has completed, there is a crash (below) because it cannot find the manifest file. Currently, the build is started but not awaited. Because of this, `web-ext` is only run successfully when by coincidence the build is finished faster than `web-ext` tries to access the manifest. In my experience, this only happens when I haven't launched Firefox since rebooting.

This pull request makes sure the initial build is awaited before launching the browser.

Error when `web-ext` runs before the build is finished:

```
npm verb cli /home/USER/.asdf/installs/nodejs/21.7.1/bin/node /home/pieterjongsma/.asdf/installs/nodejs/21.7.1/bin/npm
npm info using npm@10.5.0
npm info using node@v21.7.1
npm verb title npm run start firefox
npm verb argv "run" "start" "firefox" "--loglevel" "verbose"
npm verb logfile logs-max:10 dir:/home/pieterjongsma/.npm/_logs/2024-05-09T07_31_33_128Z-
npm verb logfile /home/pieterjongsma/.npm/_logs/2024-05-09T07_31_33_128Z-debug-0.log

> browser-extension@2.0.0 start
> node --loader ts-node/esm scripts/build.ts --dev firefox

(node:22306) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm", pathToFileURL("./"));'
(Use `node --trace-warnings ...` to show where the warning was created)
Building "background" from src/pages/background/index.js:: 106.095ms
Copying public files for v2: 18.947ms
Building "devtools" from src/pages/devtools/index.html: 24.01ms
Building "content" from src/pages/content/index.tsx:: 136.245ms
[0] Applying config file: ./package.json
[0] Running web extension from /home/pieterjongsma/Projects/2023-2024/browser-extension/dist/v2
[0] 
[0] InvalidManifest: Could not read manifest.json file at /home/pieterjongsma/Projects/2023-2024/browser-extension/dist/v2/manifest.json: Error: ENOENT: no such file or directory, open '/home/pieterjongsma/Projects/2023-2024/browser-extension/dist/v2/manifest.json'
[0] 
[0] web-ext run --start-url=example.com --profile-create-if-missing --browser-console --keep-profile-changes --source-dir="/home/pieterjongsma/Projects/2023-2024/browser-extension/dist/v2" --firefox-binary="firefox" --firefox-profile="/home/pieterjongsma/Projects/2023-2024/browser-extension/tmp/profiles/firefox" exited with code 1
web-ext run --start-url=example.com --profile-create-if-missing --browser-console --keep-profile-changes --source-dir="/home/pieterjongsma/Projects/2023-2024/browser-extension/dist/v2" --firefox-binary="firefox" --firefox-profile="/home/pieterjongsma/Projects/2023-2024/browser-extension/tmp/profiles/firefox":
 exited with code 1

file:///home/pieterjongsma/Projects/2023-2024/browser-extension/scripts/build.ts:472
                throw new Error(command.error);
                      ^

Error: [object Object]
    at file:///home/pieterjongsma/Projects/2023-2024/browser-extension/scripts/build.ts:472:23

Node.js v21.7.1
npm verb exit 1
npm verb code 1
```